### PR TITLE
Added URL and Description Customization and Overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,32 +88,50 @@ You can change the default appearance in your `config.php` file, e.g. `site/conf
   // define the style (normal, solid, circle, solidcircle)
   c::set('plugin.sharingbuttons.style', 'solid');
 
+  // define the url field
+  c::set('plugin.sharingbuttons.urlField', 'url');
+
+  // define the description field
+  c::set('plugin.sharingbuttons.descriptionField', 'title');
+
   // define the networks, their title and the order of the buttons
   c::set('plugin.sharingbuttons.networks', array(
-    'twitter' => 'Twitter',
-    'facebook' => 'Facebook',
-    'google' => 'Google+',
-    'linkedin' => 'LinkedIn',
-    'email' => 'E-Mail',
-    // 'tumblr' => 'Tumblr',
-    // 'pinterest' => 'Pinterest',
-    // 'reddit' => 'Reddit',
-    // 'xing' => 'XING',
-    // 'whatsapp' => 'WhatsApp',
-    // 'hackernews' => 'Hacker News',
-    // 'vk' => 'VK',
-    // 'telegram' => 'Telegram',
+    'twitter'     => 'Twitter',
+    'facebook'    => 'Facebook',
+    'google'      => 'Google+',
+    'linkedin'    => 'LinkedIn',
+    'email'       => 'E-Mail',
+    // 'tumblr'      => 'Tumblr',
+    // 'pinterest'   => 'Pinterest',
+    // 'reddit'      => 'Reddit',
+    // 'xing'        => 'XING',
+    // 'whatsapp'    => 'WhatsApp',
+    // 'hackernews'  => 'Hacker News',
+    // 'vk'          => 'VK',
+    // 'telegram'    => 'Telegram',
   ));
 ?>
 ```
 
 #### Override your own config
 
-In case you need different styles for different templates, you can override your own settings by adding params to the page method like this.
+In case you need different styles, URLs, or descriptions for different templates, you can override your own settings by adding params to the page method like this.
 
 ```
-<?= page()->sharingbuttons(['size' => 'medium', 'style' => 'circle', 'networks' => ['facebook' => 'Facebook','twitter' => 'Twitter']]) ?>
+<?= page()->sharingbuttons([
+    'size' => 'medium',
+    'style' => 'circle',
+    'urlField' => 'shareURL',
+    'descriptionField' => 'shareMessage',
+    'url' => 'https://getkirby.com',
+    'description' => 'Check this out.',
+    'networks' => ['facebook' => 'Facebook','twitter' => 'Twitter']
+    ]) ?>
 ```
+
+The parameter `url`, if provided, takes precedence over `urlField`.
+
+The parameter `description`, if provided, takes precedence over `descriptionField`.
 
 ### 3. Translations
 
@@ -138,9 +156,6 @@ You can find some translations in `site/plugins/sharingbuttons/languages/`. You 
 ```
 
 ## Roadmap and ideas
-
-- [ ] Possibility to set a custom field in `config.php` used as description (instead of page title)
-- [ ] Possibility to override the custom description by using page method parameter
 
 ## Credits
 

--- a/sharingbuttons.php
+++ b/sharingbuttons.php
@@ -16,25 +16,35 @@
 page::$methods['sharingbuttons'] = function($page, $config = false) {
 
   // get custom setting from config.php or set defaults
-  $size     = c::get('plugin.sharingbuttons.size','small');
-  $style    = c::get('plugin.sharingbuttons.style','solid');
-  $networks = c::get('plugin.sharingbuttons.networks', [
-    'twitter' => 'Twitter',
-    'facebook' => 'Facebook',
-    'google' => 'Google+',
-    'linkedin' => 'LinkedIn',
-    'email' => 'E-Mail',
-    // 'tumblr' => 'Tumblr',
-    // 'pinterest' => 'Pinterest',
-    // 'reddit' => 'Reddit',
-    // 'xing' => 'XING',
-    // 'whatsapp' => 'WhatsApp',
-    // 'hackernews' => 'Hacker News',
-    // 'vk' => 'VK',
-    // 'telegram' => 'Telegram',
+  $urlField         = c::get('plugin.sharingbuttons.urlField', 'url');
+  $descriptionField = c::get('plugin.sharingbuttons.descriptionField', 'title');
+  $size             = c::get('plugin.sharingbuttons.size','small');
+  $style            = c::get('plugin.sharingbuttons.style','solid');
+  $networks         = c::get('plugin.sharingbuttons.networks', [
+    'twitter'     => 'Twitter',
+    'facebook'    => 'Facebook',
+    'google'      => 'Google+',
+    'linkedin'    => 'LinkedIn',
+    'email'       => 'E-Mail',
+    // 'tumblr'      => 'Tumblr',
+    // 'pinterest'   => 'Pinterest',
+    // 'reddit'      => 'Reddit',
+    // 'xing'        => 'XING',
+    // 'whatsapp'    => 'WhatsApp',
+    // 'hackernews'  => 'Hacker News',
+    // 'vk'          => 'VK',
+    // 'telegram'    => 'Telegram',
   ]);
 
   // override with inline settings if set
+  if (!empty($config['urlField'])) {
+    $urlField = $config['urlField'];
+  }
+
+  if (!empty($config['descriptionField'])) {
+    $descriptionField = $config['descriptionField'];
+  }
+
   if (!empty($config['size']) && in_array($config['size'], ['small', 'medium', 'large'])) {
     $size = $config['size'];
   }
@@ -48,12 +58,15 @@ page::$methods['sharingbuttons'] = function($page, $config = false) {
   }
 
   // prepare data for templates
-  $data = array(
-    'url' => urlencode($page->url()),
-    'description' => urlencode($page->title()),
-    'size' => $size,
-    'style' => $style,
-  );
+  $url = (string) (isset($config['url']) ? $config['url'] : call([$page, $urlField]));
+  $description = (string) (isset($config['description']) ? $config['description'] : call([$page, $descriptionField]));
+
+  $data = [
+    'url'         => rawurlencode($url),
+    'description' => rawurlencode($description),
+    'size'        => $size,
+    'style'       => $style,
+  ];
 
   // build html brick
   $content = new Brick('div');


### PR DESCRIPTION
### Adds
- Ability to define a custom URL field to general _and_ page method configuration (for example, if you want to use `tinyurl` or some completely custom) (`urlField`)
- Ability to define a custom description field to general _and_ page method configuration (`descriptionField`)
- Ability to use an arbitrary URL as a page method parameter (`url`)
- Ability to use an arbitrary description string as a page method parameter (`description`)

### Fixes
- Uses `rawurlencode` instead of `urlencode`, because email clients tend to interpret `+` symbols as literal `+` instead of a space (for subject field).

The README also reflects the new configuration options.